### PR TITLE
Fixes crawler changed URLs after Developers Italia migration

### DIFF
--- a/devitalia/fetch-engines/engines/catalogo_stats.py
+++ b/devitalia/fetch-engines/engines/catalogo_stats.py
@@ -19,16 +19,16 @@ class Catalogo(Engine):
 
     '''
     Relevant files:
-    - https://developers.italia.it/crawler/softwares.yml
-    - https://developers.italia.it/crawler/amministrazioni.yml
-    - https://developers.italia.it/crawler/software_categories.yml
-    - https://developers.italia.it/crawler/software-open-source.yml
-    - https://developers.italia.it/crawler/software-riuso.yml
-    - https://developers.italia.it/crawler/software_scopes.yml
-    - https://developers.italia.it/crawler/software_tags.yml
+    - https://crawler.developers.italia.it/softwares.yml
+    - https://crawler.developers.italia.it/amministrazioni.yml
+    - https://crawler.developers.italia.it/software_categories.yml
+    - https://crawler.developers.italia.it/software-open-source.yml
+    - https://crawler.developers.italia.it/software-riuso.yml
+    - https://crawler.developers.italia.it/software_scopes.yml
+    - https://crawler.developers.italia.it/software_tags.yml
     '''
 
-    SOFTWARES_URL = 'https://developers.italia.it/crawler/softwares.yml'
+    SOFTWARES_URL = 'https://crawler.developers.italia.it/softwares.yml'
     INDICEPA_URL = 'https://www.indicepa.gov.it/public-services/opendata-read-service.php?dstype=FS&filename=amministrazioni.txt'
 
     softwares = None

--- a/devitalia/fetch-engines/engines/catalogoaudiences_stats.py
+++ b/devitalia/fetch-engines/engines/catalogoaudiences_stats.py
@@ -18,16 +18,16 @@ class CatalogoAudiences(Engine):
 
     '''
     Relevant files:
-    - https://developers.italia.it/crawler/softwares.yml
-    - https://developers.italia.it/crawler/amministrazioni.yml
-    - https://developers.italia.it/crawler/software_categories.yml
-    - https://developers.italia.it/crawler/software-open-source.yml
-    - https://developers.italia.it/crawler/software-riuso.yml
-    - https://developers.italia.it/crawler/software_scopes.yml
-    - https://developers.italia.it/crawler/software_tags.yml
+    - https://crawler.developers.italia.it/softwares.yml
+    - https://crawler.developers.italia.it/amministrazioni.yml
+    - https://crawler.developers.italia.it/software_categories.yml
+    - https://crawler.developers.italia.it/software-open-source.yml
+    - https://crawler.developers.italia.it/software-riuso.yml
+    - https://crawler.developers.italia.it/software_scopes.yml
+    - https://crawler.developers.italia.it/software_tags.yml
     '''
 
-    SOFTWARES_URL = 'https://developers.italia.it/crawler/softwares.yml'
+    SOFTWARES_URL = 'https://crawler.developers.italia.it/softwares.yml'
 
     softwares = None
     administrations = None

--- a/devitalia/fetch-engines/engines/catalogocategories_stats.py
+++ b/devitalia/fetch-engines/engines/catalogocategories_stats.py
@@ -17,16 +17,16 @@ class CatalogoCategories(Engine):
 
     '''
     Relevant files:
-    - https://developers.italia.it/crawler/softwares.yml
-    - https://developers.italia.it/crawler/amministrazioni.yml
-    - https://developers.italia.it/crawler/software_categories.yml
-    - https://developers.italia.it/crawler/software-open-source.yml
-    - https://developers.italia.it/crawler/software-riuso.yml
-    - https://developers.italia.it/crawler/software_scopes.yml
-    - https://developers.italia.it/crawler/software_tags.yml
+    - https://crawler.developers.italia.it/softwares.yml
+    - https://crawler.developers.italia.it/amministrazioni.yml
+    - https://crawler.developers.italia.it/software_categories.yml
+    - https://crawler.developers.italia.it/software-open-source.yml
+    - https://crawler.developers.italia.it/software-riuso.yml
+    - https://crawler.developers.italia.it/software_scopes.yml
+    - https://crawler.developers.italia.it/software_tags.yml
     '''
 
-    SOFTWARES_URL = 'https://developers.italia.it/crawler/softwares.yml'
+    SOFTWARES_URL = 'https://crawler.developers.italia.it/softwares.yml'
 
     softwares = None
     administrations = None

--- a/devitalia/fetch-engines/engines/catalogoregioni_stats.py
+++ b/devitalia/fetch-engines/engines/catalogoregioni_stats.py
@@ -18,17 +18,16 @@ class CatalogoRegioni(Engine):
 
     '''
     Relevant files:
-    - https://developers.italia.it/crawler/softwares.yml
-    - https://developers.italia.it/crawler/amministrazioni.yml
-    - https://developers.italia.it/crawler/software_categories.yml
-    - https://developers.italia.it/crawler/software-open-source.yml
-    - https://developers.italia.it/crawler/software-riuso.yml
-    - https://developers.italia.it/crawler/software_scopes.yml
-    - https://developers.italia.it/crawler/software_tags.yml
+    - https://crawler.developers.italia.it/softwares.yml
+    - https://crawler.developers.italia.it/amministrazioni.yml
+    - https://crawler.developers.italia.it/software_categories.yml
+    - https://crawler.developers.italia.it/software-open-source.yml
+    - https://crawler.developers.italia.it/software-riuso.yml
+    - https://crawler.developers.italia.it/software_scopes.yml
+    - https://crawler.developers.italia.it/software_tags.yml
     '''
 
-    #REPOLIST_URL = 'https://onboarding.developers.italia.it/repo-list'
-    SOFTWARES_URL = 'https://developers.italia.it/crawler/softwares.yml'
+    SOFTWARES_URL = 'https://crawler.developers.italia.it/softwares.yml'
     INDICEPA_URL = 'https://www.indicepa.gov.it/public-services/opendata-read-service.php?dstype=FS&filename=amministrazioni.txt'
 
     regioni = [

--- a/devitalia/fetch-engines/engines/onboarding_stats.py
+++ b/devitalia/fetch-engines/engines/onboarding_stats.py
@@ -17,17 +17,17 @@ class Onboarding(Engine):
 
     '''
     Relevant files:
-    - https://developers.italia.it/crawler/softwares.yml
-    - https://developers.italia.it/crawler/amministrazioni.yml
-    - https://developers.italia.it/crawler/software_categories.yml
-    - https://developers.italia.it/crawler/software-open-source.yml
-    - https://developers.italia.it/crawler/software-riuso.yml
-    - https://developers.italia.it/crawler/software_scopes.yml
-    - https://developers.italia.it/crawler/software_tags.yml
+    - https://crawler.developers.italia.it/softwares.yml
+    - https://crawler.developers.italia.it/amministrazioni.yml
+    - https://crawler.developers.italia.it/software_categories.yml
+    - https://crawler.developers.italia.it/software-open-source.yml
+    - https://crawler.developers.italia.it/software-riuso.yml
+    - https://crawler.developers.italia.it/software_scopes.yml
+    - https://crawler.developers.italia.it/software_tags.yml
     '''
 
     REPO_LIST = 'https://onboarding.developers.italia.it/repo-list'
-    SOFTWARES_URL = 'https://developers.italia.it/crawler/softwares.yml'
+    SOFTWARES_URL = 'https://crawler.developers.italia.it/softwares.yml'
 
     pas = None
     softwares = None


### PR DESCRIPTION
Later on all Developers Italia migration we have changed the location where crawler serves its generated files in a dedicated third level domain.
More infos here: https://github.com/italia/developers.italia.it/pull/529
