### PR TITLE
Add an incremental mode to github engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Set vars
 ENV DEBIAN_FRONTEND noninteractive

--- a/devitalia/fetch-engines/engines/engine.py
+++ b/devitalia/fetch-engines/engines/engine.py
@@ -6,7 +6,7 @@ import os
 import logging
 import logging.config
 
-class Engine:
+class Engine(object):
     name = None
     logger = None
     args = None
@@ -30,7 +30,7 @@ class Engine:
     def get_property(self, property_name):
         if getattr(self.args, property_name, None):
             return getattr(self.args, property_name)
-        
+
         # hack to keep backslah not doubled from encodind in env vars
         return bytes(os.getenv(property_name.upper()), 'latin1').decode('unicode_escape')
 
@@ -61,7 +61,7 @@ class Engine:
         """
         if timestamp not in self.metrics:
             self.metrics[timestamp] = {}
-        
+
             for metric in self.metric_names:
                 self.metrics[timestamp][metric] = 0
 

--- a/devitalia/fetch-engines/engines/github_stats.py
+++ b/devitalia/fetch-engines/engines/github_stats.py
@@ -1,30 +1,49 @@
 #!/usr/bin/env python3
 
+import csv
 import json
 import re
-import concurrent.futures
 import time
-import datetime
+from datetime import datetime, timezone
 import requests
 
 from .engine import Engine
 
+
+def response_is(response, code, message):
+    """Convert an ISO 8601 string with timezone in a datetime object.
+
+    Args:
+        s (str): The ISO 8601 string
+    Returns
+        The datetime object
+    """
+
+    if response.content:
+        answer = json.loads(response.content)
+
+    return (response.status_code == code
+            and (answer
+                 and 'message' in answer
+                 and message in answer['message']))
+
+def to_datetime(s):
+    """Convert an ISO 8601 string with timezone in a datetime object.
+
+    Args:
+        s (str): The ISO 8601 string
+    Returns
+        The datetime object
+    """
+    return datetime.strptime(s, "%Y-%m-%dT%H:%M:%S%z")
+
+
 class GitHub(Engine):
     """
-    Class that computes the statistics from GitHub repos of /italia organization.
-    The class, to work, needs to have the key from a user with push access to the repos to execute.
-    (the key can be created from this link: https://github.com/settings/tokens).
-    All the statistics will be computed form the GitHub APIs.
+    Fetches the statistics from GitHub's API for repos in the /italia organization.
 
-    Example of results:
-    # python main.py -t github
-    Membri dell'organizzazione: 127.
-    Numero di repo: 250.
-    Numero di fork: 1,220.
-    Numero di contributors distinti: 1,904.
-    Numero di commit: 704,826.
-    Numero di pull request: 5,610.
-    Numero di clone: 945.
+    It needs a GitHub token with push access to the repos to get the full stats
+    (https://github.com/settings/tokens).
     """
 
     repos = None
@@ -34,29 +53,43 @@ class GitHub(Engine):
         super(GitHub, self).__init__(args, 'github')
         self.metric_names = ['num_members', 'num_repos', 'num_forks', 'num_contribs', 'num_commits', 'num_pr', 'num_clones']
 
-    def _multiple_api_calls(self, url, iterlist, reduce=True):
-        ritorno = {}
+        if args.incremental:
+            csv_path = "{}/{}.csv".format(args.data_dir, self.name)
+            with open(csv_path, "r") as f:
+                rows = csv.reader(f)
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=self.num_threads) as executor:
-            futures = {executor.submit(self._api_call, url.format(p), reduce, p): p for p in iterlist}
-            for future in concurrent.futures.as_completed(futures):
-                name = futures[future]
                 try:
-                    ritorno[name] = future.result()
-                except Exception as e:
-                    self.logger.error('%s generated an exception: %s', name, e)
-            
-        return ritorno
-                    
+                    next(rows)  # Skip the header
+                    last_row = (next(reversed(list(rows))))
+
+                    ts = last_row[0]
+                except (StopIteration, IndexError):
+                    self.logger.error('--incremental needs at least one timestamp in %s.', csv_path)
+                    raise
+
+            self.args.since = datetime.strptime(ts, '%Y-%m-%dT%H:%M:%S%z')
+
+    def _multiple_api_calls(self, url, repo_names, reduce=True):
+        ret = {}
+
+        for repo_name in repo_names:
+            result = self._api_call(url.format(repo_name), reduce, repo_name)
+            if result is not None:
+                ret[repo_name] = result
+
+        return ret
+
     def _api_call(self, url, reduce=True, name=None):
         if name is not None:
-            self.logger.debug('Calling API for repo {}...'.format(name))
+            self.logger.debug('Calling API for repo {} ({})...'.format(name, url))
+        else:
+            self.logger.debug('Calling {}'.format(url))
 
         headers = {'Authorization': 'token {}'.format(self.get_property('token_github'))}
 
-        ritorno = []
+        ret = []
         link = "{}?per_page=1000".format(url)
-        
+
         while link is not None:
             while True:
                 r = requests.get(link, headers=headers)
@@ -65,101 +98,144 @@ class GitHub(Engine):
                 if r.content:
                     answer = json.loads(r.content)
 
+                # If we get rate-limited, take the hint and sleep until the reset time GitHub
+                # provides us in the headers.
+                #
                 # 429 is returned when the API register too many requests from the same client.
-                # In this case wait some time and then retry the call.
-                # Check also of the call returned an error message specifying you've triggered an abuse.
-                if r.status_code == 429 or (answer and 'message' in answer and 'You have triggered an abuse detection mechanism' in answer['message']):
-                    self.logger.debug("Rate limit reached, waiting 5 second.")
-                    time.sleep(5)
-                    self.logger.debug("Restarting API calls.")
+                if (r.status_code == 429
+                        or response_is(r, 403, 'API rate limit exceeded for user')
+                        or response_is(r, 403, 'You have triggered an abuse detection mechanism')):
+
+                    now = datetime.now(tz=timezone.utc)
+                    until = datetime.fromtimestamp(int(r.headers['X-RateLimit-Reset']), tz=timezone.utc)
+                    if until < now:
+                        until = now
+
+                    self.logger.debug("Rate limit reached, waiting until %s", until)
+                    time.sleep((until - now).total_seconds())
+                    self.logger.debug("Resuming API calls.")
                 else:
                     break
-            
-            if r.status_code not in [200, 422, 409]:
+
+            # Ignore empty repositories
+            if response_is(r, 409, 'Git Repository is empty'):
+                return None
+
+            if r.status_code not in [200, 422]:
                 if answer and 'message' in answer:
                     raise Exception('An error occurred while calling GitHub ({}): {}'.format(r.status_code, answer['message']))
-                
+
                 raise Exception('An error occurred while calling GitHub ({}).'.format(r.status_code))
 
-            if 'message' in answer:
-                raise Exception('The call returned following message: {}'.format(answer['message']))
-
-            ritorno.append(answer)
+            ret.append(answer)
 
             link = r.headers.get('link', None)
             if link is not None and re.search(r'; rel="next"', link):
                 link = re.sub(r'.*<(.*)>; rel="next".*', r'\1', link)
             else:
                 link = None
-        
-        if reduce:
-            ritorno = [val for sublist in ritorno for val in sublist]
 
-        return ritorno
+        if reduce:
+            ret = [val for sublist in ret for val in sublist]
+
+        return ret
+
+    def _all_repos(self):
+        """Fetch all the repos in the organization from day one.
+
+        Returns: A list of dicts representing the repos.
+        """
+
+        if self.repos is None:
+            self.repos = self._api_call('https://api.github.com/users/italia/repos', True)
+
+        return self.repos
+
+    def _all_commits_since(self):
+        """Fetch all the commits in the organization.
+
+        Returns: A list of dicts representing the commits.
+        """
+
+        if self.commits is None:
+            self.logger.info('Getting commits from repos...')
+
+            repo_names = [r['name'] for r in self._all_repos()]
+
+            url = 'https://api.github.com/repos/italia/{}/commits'
+            if self.args.since is not None:
+                url += '?since={}'.format(self.args.since.strftime('%Y-%m-%dT%H:%M:%SZ'))
+
+            self.commits = self._multiple_api_calls(url, repo_names, True)
+
+        return self.commits
 
     def num_members(self):
-        """
-        Computable from https://api.github.com/orgs/italia/members by counting the elements of the returned array.
-        Numeric indicator of the counting of all the members of the GitHub organization.
+        """Fetch the count of all members in the GitHub organization.
+
+        It needs a token of a member of @italia to list both public and concealed members.
+        This doesn't respect --since.
         """
 
         self.logger.info('Getting members...')
+
+        # Use /members and count the elements of the returned array.
         members = self._api_call('https://api.github.com/orgs/italia/members', True)
 
-        timestamp = self.strip_date(datetime.datetime.now())
+        timestamp = self.strip_date(datetime.now(tz=timezone.utc))
         self.add_timestamp_to_metrics(timestamp)
 
         self.metrics[timestamp]['num_members'] = len(members)
 
     def num_repos(self):
-        """
-        Computable from https://api.github.com/users/italia/repos by counting the elements of the returned array.
-        Numeric indicator of the counting of all the repos of the GitHub organization.
-        """
+        """Fetch the repos and index them by creation date."""
 
         self.logger.info('Getting repos...')
-        self.repos = self._api_call('https://api.github.com/users/italia/repos', True)
+        repos = self._all_repos()
 
-        for r in self.repos:
+        if self.args.since is not None:
+            repos = [r for r in repos if to_datetime(r['created_at']) >= self.args.since]
+
+        for r in repos:
             timestamp = self.strip_date(r['created_at'])
             self.add_timestamp_to_metrics(timestamp)
 
             self.metrics[timestamp]['num_repos'] += 1
 
     def num_forks(self):
-        """
-        Computable from https://api.github.com/users/italia/repos by counting all the `forks_count` for all the repos.
-        Numeric indicator of the forks for all the project of the GitHub organization.
-        """
+        """Fetch the forks and index them by creation date."""
 
-        if self.repos is None:
-            self.num_repos()
+        self.logger.info('Getting forks...')
 
-        repo_names = [r['name'] for r in self.repos]
-        forks = self._multiple_api_calls('https://api.github.com/repos/italia/{}/forks', repo_names, True)
+        repo_names = [r['name'] for r in self._all_repos()]
+        res = self._multiple_api_calls('https://api.github.com/repos/italia/{}/forks', repo_names, True)
 
-        for r in forks:
-            for f in forks[r]:
+        for _repo, forks in res.items():
+            if self.args.since is not None:
+                forks = [f for f in forks if to_datetime(f['created_at']) >= self.args.since]
+
+            for f in forks:
                 timestamp = self.strip_date(f['created_at'])
                 self.add_timestamp_to_metrics(timestamp)
 
                 self.metrics[timestamp]['num_forks'] += 1
 
     def num_contribs(self):
-        """
-        Computable from https://api.github.com/repos/italia/{REPONAME}/commits by summing all the commits
-        for every different author on evenry repo obtained from the previous call.
-        Numeric indicator of the number of contributors that made at least one commit on one of the
-        projects of the GitHub organization.
-        """
+        """Fetch the contribs that made at least one commit on one of the projects
+        and index them by creation date."""
 
-        self.logger.info('Getting commits from repos...')
-        if self.commits is None:
-            self.num_commits()
-        
-        for a in self.commits:
+        self.logger.info('Getting contribs...')
+
+        for a in self._all_commits_since():
             for c in self.commits[a]:
                 timestamp = self.strip_date(c['commit']['author']['date'])
+
+                # XXX: GitHub sometimes returns commits older than 'since' for some reason.
+                # Let's discard those.
+                if self.args.since is not None and to_datetime(timestamp) <= self.args.since:
+                    continue
+
+                self.add_timestamp_to_metrics(timestamp)
 
                 if self.metrics[timestamp]['num_contribs'] == 0:
                     self.metrics[timestamp]['num_contribs'] = []
@@ -173,64 +249,99 @@ class GitHub(Engine):
                     self.metrics[t]['num_contribs'] = len(self.metrics[t]['num_contribs'])
 
     def num_commits(self):
-        """
-        Computable from https://api.github.com/repos/italia/{REPONAME}/commits by summing all the counting of the commits
-        on all the repos obtained by the previous call.
-        Numeric indicator of the number of commits made on all the projects of the GitHub organization.
-        """
+        """Fetch the commits made to all the projects in the GitHub organization and index them
+        by creation date."""
 
-        self.logger.info('Getting commits from repos...')
-        if self.repos is None:
-            self.num_repos()
-
-        repo_names = [r['name'] for r in self.repos]
-        self.commits = self._multiple_api_calls('https://api.github.com/repos/italia/{}/commits', repo_names, True)
-
-        for a in self.commits.keys():
+        self.logger.info('Getting commits...')
+        for a in self._all_commits_since().keys():
             for c in self.commits[a]:
                 timestamp = self.strip_date(c['commit']['author']['date'])
+
+                # XXX: GitHub sometimes returns commits older than 'since' for some reason.
+                # Let's discard those.
+                if self.args.since is not None and to_datetime(timestamp) <= self.args.since:
+                    continue
+
                 self.add_timestamp_to_metrics(timestamp)
 
                 self.metrics[timestamp]['num_commits'] += 1
 
     def num_pr(self):
-        """
-        Computable from https://api.github.com/repos/italia/{REPONAME}/pulls by summing all the counting
-        of the elements returned for every repo obtained from the previous call.
-        Numeric indicator of the number of pull requests made on all the projects in the GitHub organization.
-        """
+        """Fetch the pull requests made on all the projects in the GitHub organization."""
 
-        self.logger.info('Getting pulls from repos...')
-        if self.repos is None:
-            self.num_repos()
+        self.logger.info('Getting PRs from repos...')
 
-        repo_names = [r['name'] for r in self.repos]
-        pulls = self._multiple_api_calls('https://api.github.com/repos/italia/{}/pulls?state=all', repo_names, True)
+        repo_names = [r['name'] for r in self._all_repos()]
 
-        for p in pulls:
-            for r in pulls[p]:
-                timestamp = self.strip_date(r['created_at'])
+        # Use /issues because /pulls doesn't provide a 'since' argument
+        url = 'https://api.github.com/repos/italia/{}/issues?state=all'
+        if self.args.since is not None:
+            url += '?since={}'.format(self.args.since.strftime('%Y-%m-%dT%H:%M:%SZ'))
+
+        res = self._multiple_api_calls(url, repo_names, True)
+
+        for _repo, pulls in res.items():
+            pulls = [p for p in pulls if 'pull_request' in p]
+
+            if self.args.since is not None:
+                # /issues also returns the PRs _updated_ after '--since', but we
+                # don't want those.
+                pulls = [
+                    p for p in pulls
+                    if datetime.strptime(p['created_at'], "%Y-%m-%dT%H:%M:%S%z") >= self.args.since
+                ]
+
+            for p in pulls:
+                timestamp = self.strip_date(p['created_at'])
                 self.add_timestamp_to_metrics(timestamp)
 
                 self.metrics[timestamp]['num_pr'] += 1
 
     def num_clones(self):
+        """Fetch the git clones not older than 14 days made from projects
+        in the GitHub organization.
+
+        It needs a GitHub token with push access to the repos.
         """
-        Computable from https://api.github.com/repos/italia/{REPONAME}/commits/traffic/clones by counting
-        all the clones in the response to the call for every repo obtained from the previous call.
-        Numeric indicator of all the git clones made on projects in the GitHub organization.
-        """
-        
+
         self.logger.info('Getting clones from repos...')
-        if self.repos is None:
-            self.num_repos()
 
-        repo_names = [r['name'] for r in self.repos]
-        clones = self._multiple_api_calls('https://api.github.com/repos/italia/{}/traffic/clones', repo_names, False)
+        repo_names = [r['name'] for r in self._all_repos()]
+        ret = self._multiple_api_calls('https://api.github.com/repos/italia/{}/traffic/clones', repo_names, False)
 
-        for a in clones:
-            for c in clones[a][0]['clones']:
+        for _repo, clones in ret.items():
+            clones = clones[0]['clones']
+            if self.args.since is not None:
+                clones = [c for c in clones if to_datetime(c['timestamp']) >= self.args.since]
+
+            for c in clones:
                 timestamp = self.strip_date(c['timestamp'])
                 self.add_timestamp_to_metrics(timestamp)
 
                 self.metrics[timestamp]['num_clones'] += c['count']
+
+    def compute_stats(self):
+        today = datetime.now(tz=timezone.utc).date()
+
+        super(GitHub, self).compute_stats()
+
+        # Filter out bogus stats in the future, if any.
+        self.metrics = {
+            ts: v for ts, v in self.metrics.items()
+            if to_datetime(ts).date() <= today
+        }
+
+        # Put 'num_members' in the second to last metric, cause we're going
+        # to discard the last one (today's).
+        iterator = reversed(sorted(self.metrics))
+        last_ts = next(iterator)
+        try:
+            second_last_ts = next(iterator)
+            self.metrics[second_last_ts]['num_members'] = self.metrics[last_ts]['num_members']
+        except StopIteration:
+            pass
+
+        # Remove today's data as it's not complete yet.
+        del self.metrics[last_ts]
+
+        return self.metrics

--- a/devitalia/fetch.sh
+++ b/devitalia/fetch.sh
@@ -67,7 +67,6 @@ if [ "${DEVITALIA_GOOGLE_CLIENT_X509_CERT_URL}" == "unset" ]; then
 fi
 
 python3 ${SCRIPTDIR}/devitalia/fetch-engines/main.py \
-    -w \
     --data_dir "${DEVITALIA_DATADIR}" \
     --num_threads "${DEVITALIA_NUM_THREADS}" \
     --token_github "${DEVITALIA_TOKEN_GITHUB}" \


### PR DESCRIPTION
I think the aggressive rate limiting we are experiencing is because of [concurrent calls](https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-abuse-rate-limits) and the removal of threading should fix that by itself.

Running with `NUM_THREADS=1` on my local machine takes about 13 minutes (~1600 API calls). I'd say it's tolerable even without `--incremental`, but I added the other goodies for good measure.

`--incremental` takes about 5 minutes (~8000 calls).

We could probably save a little bit of data transfer using GitHub's GraphQL APIs, but all thing considered I don't think that's worth the effort.

Down side: we need to keep `github.csv` around for `--incremental`.
@libremente @sebbalex WDYT?